### PR TITLE
Import fail with no pilot

### DIFF
--- a/custom_plugins/multigp_toolkit/rsimporter.py
+++ b/custom_plugins/multigp_toolkit/rsimporter.py
@@ -410,7 +410,7 @@ class RaceSyncImporter:
         format_id, mgp_format = format_data
         rh_race_name = str(race_data["name"])
 
-        for mgp_pilot in race_data["entries"]:
+        for mgp_pilot in race_data.get("entries", []):
             self.pilot_search(mgp_pilot, update_attrs=True)
 
         if (

--- a/custom_plugins/multigp_toolkit/rsimporter.py
+++ b/custom_plugins/multigp_toolkit/rsimporter.py
@@ -202,7 +202,7 @@ class RaceSyncImporter:
             self._rhapi.ui.message_notify(self._rhapi.language.__(message))
             return
 
-        for mgp_pilot in race_data["entries"]:
+        for mgp_pilot in race_data.get("entries", []):
             self.pilot_search(mgp_pilot, update_attrs=True)
 
         self._rhapi.ui.broadcast_pilots()


### PR DESCRIPTION
Fix for issue https://github.com/i-am-grub/multigp_toolkit/issues/24
Basically if there are no pilots, it just return [] and therefor loop doesnt crash. 

Happens during event import and pilot import. 