### PR TITLE
Removed the 3 pilot minimum limit per heat as per 2026 upate

### DIFF
--- a/custom_plugins/multigp_toolkit/rhcoordinator.py
+++ b/custom_plugins/multigp_toolkit/rhcoordinator.py
@@ -494,11 +494,6 @@ class RaceSyncCoordinator:
         if pilot_counter == 0:
             return False
 
-        if gq_active and pilot_counter < 3:
-            message = "GQ Rules: At least 3 pilots are required to start the race"
-            self._rhapi.ui.message_alert(self._rhapi.language.__(message))
-            return False
-
         return True
 
     def _race_zippyq_checks(self, heat_info: Heat) -> bool:

--- a/docs/usage/running/index.rst
+++ b/docs/usage/running/index.rst
@@ -136,7 +136,7 @@ a class that was imported as a Global Qualifier (Controlled or ZippyQ).
     race director when a mandatory update is available for 
     either RotorHazard or the MultiGP Toolkit
 
-- A minimum of 3 pilots are required per heat
+- A minimum of 1 pilot must be registered in the heat for the results to be uploaded to MultiGP
 - The imported class from MultiGP can not be altered and must be used for the Global Qualifier event (results will not be uploaded otherwise)
 - The format assigned to the imported class from MultiGP cannot be altered with exception to the settings that manage the start/stop behavior of the timer
 - Other plugins can not be used to register laps


### PR DESCRIPTION
https://docs.google.com/document/d/1Jpg1UQT6Q4GK58MPrs0SlsK6SriNQCWZdix-k9HiaI8/edit?tab=t.0#heading=h.sbpcogjcsr6g

2026 update doesnt require 3 minimum pilots per heat for Global Qualifier. 